### PR TITLE
Fix Amex APPROVED response text not recognised as success (WM #12958)

### DIFF
--- a/src/Message/AcceptNotification.php
+++ b/src/Message/AcceptNotification.php
@@ -59,7 +59,7 @@ class AcceptNotification extends PurchaseRequest implements NotificationInterfac
 
     public function getTransactionStatus()
     {
-        if ($this->getTransaction() && $this->getAuthorised() && $this->getResponseText() === 'APPROVED') {
+        if ($this->getTransaction() && $this->getAuthorised() && str_starts_with($this->getResponseText(), 'APPROVED')) {
             return static::STATUS_COMPLETED;
         }
 

--- a/src/Message/CompletePurchaseResponse.php
+++ b/src/Message/CompletePurchaseResponse.php
@@ -31,7 +31,7 @@ class CompletePurchaseResponse extends AbstractResponse
         return (
             $transaction &&
             ($transaction['authorised'] ?? false) &&
-            ( strtoupper($transaction['responseText'] ?? '') ) === 'APPROVED'
+            str_starts_with(strtoupper($transaction['responseText'] ?? ''), 'APPROVED')
         ) ?? false;
     }
 

--- a/tests/Message/CompletePurchaseResponseTest.php
+++ b/tests/Message/CompletePurchaseResponseTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Omnipay\WindcaveHpp\Message;
+
+use Omnipay\Tests\TestCase;
+
+class CompletePurchaseResponseTest extends TestCase
+{
+    private function makeResponse(array $transactionOverrides = []): CompletePurchaseResponse
+    {
+        $transaction = array_merge([
+            'authorised'      => true,
+            'responseText'    => 'APPROVED',
+            'merchantReference' => 'ref-123',
+            'id'              => 'txn-456',
+            'type'            => 'purchase',
+            'method'          => 'card',
+            'card'            => [],
+        ], $transactionOverrides);
+
+        return new CompletePurchaseResponse($this->getMockRequest(), [
+            'transactions' => [$transaction],
+        ]);
+    }
+
+    public function testIsSuccessfulWithApproved(): void
+    {
+        $this->assertTrue($this->makeResponse(['responseText' => 'APPROVED'])->isSuccessful());
+    }
+
+    public function testIsSuccessfulWithApprovedAmex(): void
+    {
+        // Amex returns "APPROVED (00)" rather than plain "APPROVED"
+        $this->assertTrue($this->makeResponse(['responseText' => 'APPROVED (00)'])->isSuccessful());
+    }
+
+    public function testIsSuccessfulWithLowercaseApproved(): void
+    {
+        $this->assertTrue($this->makeResponse(['responseText' => 'approved'])->isSuccessful());
+    }
+
+    public function testIsNotSuccessfulWhenDeclined(): void
+    {
+        $this->assertFalse($this->makeResponse(['responseText' => 'DECLINED', 'authorised' => false])->isSuccessful());
+    }
+
+    public function testIsNotSuccessfulWhenNotAuthorised(): void
+    {
+        $this->assertFalse($this->makeResponse(['authorised' => false])->isSuccessful());
+    }
+
+    public function testIsNotSuccessfulWithEmptyTransactions(): void
+    {
+        $response = new CompletePurchaseResponse($this->getMockRequest(), ['transactions' => []]);
+        $this->assertFalse($response->isSuccessful());
+    }
+
+    public function testGetMessage(): void
+    {
+        $response = $this->makeResponse(['responseText' => 'APPROVED (00)']);
+        $this->assertSame('APPROVED (00)', $response->getMessage());
+    }
+}


### PR DESCRIPTION
Windcave sometimes is returning "APPROVED (00)" instead of plain "APPROVED". The strict equality checks in isSuccessful() and getTransactionStatus() failed to match this, causing approved transactions to be treated as errors.